### PR TITLE
Potential fix for code scanning alert no. 8: DOM text reinterpreted as HTML

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,16 @@
 window.appConfig = window.appConfig || {};
 let lastTitleData = null;
 
+// CSSファイル名を検証して安全なもののみ許可
+function sanitizeCssFilename(name) {
+    // 許可されたファイル名のみ: 英数字, -, _, .css, 拡張子のみ
+    if (typeof name !== "string") return "battle.css";
+    const allowed = /^[\w\-]+\.css$/;
+    if (allowed.test(name)) return name;
+    // 不正な場合はデフォルトへ
+    return "battle.css";
+}
+
 function renderTitle(data) {
     if (!data) return;
     document.getElementById("Compe-name").textContent = data.compename || "";
@@ -94,7 +104,8 @@ if (window.electron) {
                         if (p) link.setAttribute('href', p); else link.setAttribute('href','css/battle.css');
                     }).catch(()=>link.setAttribute('href','css/battle.css'));
                 } else {
-                    link.setAttribute("href", `css/${val}`);
+                    const safeVal = sanitizeCssFilename(val);
+                    link.setAttribute("href", `css/${safeVal}`);
                 }
             }
         }
@@ -119,7 +130,8 @@ document.addEventListener("DOMContentLoaded", () => {
                         if (p) link.setAttribute('href', p); else link.setAttribute('href','css/battle.css');
                     }).catch(()=>link.setAttribute('href','css/battle.css'));
                 } else {
-                    link.setAttribute("href", `css/${cssTheme}`);
+                    const safeCssTheme = sanitizeCssFilename(cssTheme);
+                    link.setAttribute("href", `css/${safeCssTheme}`);
                 }
             }
         } catch {}


### PR DESCRIPTION
Potential fix for [https://github.com/blackstraysheep/Kuawase/security/code-scanning/8](https://github.com/blackstraysheep/Kuawase/security/code-scanning/8)

To fix the problem, the value inserted into the `href` attribute should be validated and sanitized such that only safe, expected values are allowed. Specifically, `cssTheme` should be constrained to a known list of allowed filenames, or, if allowing user uploads (e.g., `user:` prefix as in current code), ensure that only valid CSS filenames with safe characters are used and reject or sanitize any other inputs.  
- Only permit filenames matching a specific regex (letters, numbers, dash/underscore, and `.css` extension) and disallow directory traversal sequences, URL schemes (`javascript:`), etc.
- If the value is not valid, fall back to a safe default (such as `'battle.css'`).
- This validation should occur before interpolating the value into the template literal assigned to `href`.
- We implement a `sanitizeCssFilename` function right in `index.js`, to be used in both the dynamic messages and DOMContentLoaded handlers, wrapping the value before constructing `css/${...}`.

No imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
