### PR TITLE
Potential fix for code scanning alert no. 10: DOM text reinterpreted as HTML

### DIFF
--- a/top.js
+++ b/top.js
@@ -1,10 +1,26 @@
 window.appConfig = window.appConfig || {};
 let lastTitleData = null;
 
+
 /**
- * 大会名を描画する
- * @param {{ compename?: string }} data
+ * CSSファイル名を安全に検証・サニタイズする
+ * @param {string} name
+ * @returns {string} サニタイズ後ファイル名 or "battle.css" fallback
  */
+function sanitizeCssFileName(name) {
+    if (!name) return "battle.css";
+    if (name.startsWith("user:")) {
+        const fname = name.slice(5);
+        // Only allow alphanumerics, -, _, ., no slashes or special chars
+        if (/^[\w\-\.]+\.css$/.test(fname)) return name;
+        // fallback
+        return "battle.css";
+    }
+    // For built-in themes, only allow alphanumerics, -, _, and .css ending
+    if (/^[\w\-]+\.css$/.test(name)) return name;
+    // fallback
+    return "battle.css";
+}
 function renderTitle(data) {
     if (!data) return;
     const el = document.getElementById("Compe-name");
@@ -71,7 +87,9 @@ document.addEventListener("DOMContentLoaded", async () => {
                     if (p) link.setAttribute('href', p); else link.setAttribute('href','css/battle.css');
                 }).catch(()=>link.setAttribute('href','css/battle.css'));
             } else {
-                link.setAttribute("href", `css/${cssTheme}`);
+                // Sanitize cssTheme before using
+                const safeTheme = sanitizeCssFileName(cssTheme);
+                link.setAttribute("href", `css/${safeTheme}`);
             }
         }
     } catch {}
@@ -91,7 +109,9 @@ window.addEventListener("message", (event) => {
                     if (p) link.setAttribute('href', p); else link.setAttribute('href','css/battle.css');
                 }).catch(()=>link.setAttribute('href','css/battle.css'));
             } else {
-                link.setAttribute("href", `css/${val}`);
+                // Sanitize val before using
+                const safeTheme = sanitizeCssFileName(val);
+                link.setAttribute("href", `css/${safeTheme}`);
             }
         }
     }


### PR DESCRIPTION
Potential fix for [https://github.com/blackstraysheep/Kuawase/security/code-scanning/10](https://github.com/blackstraysheep/Kuawase/security/code-scanning/10)

To prevent this vulnerability, every variable used to set the CSS file location (`cssTheme` and similar) must be restricted to safe values. We'll use a whitelist approach:

- For built-in themes, only allow values matching a safe filename pattern (e.g., `/^[\w\-]+\.css$/`).
- For user themes prefixed with `"user:"`, sanitize the portion after `"user:"` to only allow safe CSS filenames (e.g., `/^[\w\-\.]+$/`).
- If sanitization fails, fall back to a default theme file (such as `"battle.css"`).

This logic needs to be applied wherever such values are used, specifically at:
- `link.setAttribute("href", ...)` on line 74 (and similarly within the `message` event on line 94).
- Any repeated code blocks with the same pattern (e.g., for `"user:"` themes).

We'll add a helper function to sanitize/validate the filename, and replace the assignment code to use only the validated value. No extra dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
