### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete multi-character sanitization

### DIFF
--- a/js/sanitize.js
+++ b/js/sanitize.js
@@ -73,7 +73,13 @@ function sanitizeHTML(content, options = {}) {
  */
 function fallbackSanitize(content) {
     // scriptタグを完全に除去
-    let sanitized = content.replace(/<script[^>]*>.*?<\/script>/gi, '');
+    // <script> タグを完全に除去するため、繰り返し適用
+    let sanitized = content;
+    let previous;
+    do {
+        previous = sanitized;
+        sanitized = sanitized.replace(/<script[^>]*>.*?<\/script>/gi, '');
+    } while (sanitized !== previous);
     
     // 危険なjavascript:プロトコルを除去
     sanitized = sanitized.replace(/javascript:/gi, '');


### PR DESCRIPTION
Potential fix for [https://github.com/blackstraysheep/Kuawase/security/code-scanning/5](https://github.com/blackstraysheep/Kuawase/security/code-scanning/5)

To effectively remove all instances of script tags and their contents, we need to repeatedly apply the script-removing replacement until no further changes occur, ensuring nested or malformed sequences are removed no matter how many layers deep. This can be achieved through a loop that continues to apply the regular expression replacement until the output stabilizes. Only lines inside the `fallbackSanitize` function should be changed; specifically line 76. No changes to logic or allowed tags. No additional imports are needed for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
