### PR TITLE
Potential fix for code scanning alert no. 4: Bad HTML filtering regexp

### DIFF
--- a/js/sanitize.js
+++ b/js/sanitize.js
@@ -73,7 +73,7 @@ function sanitizeHTML(content, options = {}) {
  */
 function fallbackSanitize(content) {
     // scriptタグを完全に除去
-    let sanitized = content.replace(/<script[^>]*>.*?<\/script>/gi, '');
+    let sanitized = content.replace(/<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi, '');
     
     // 危険なjavascript:プロトコルを除去
     sanitized = sanitized.replace(/javascript:/gi, '');


### PR DESCRIPTION
Potential fix for [https://github.com/blackstraysheep/Kuawase/security/code-scanning/4](https://github.com/blackstraysheep/Kuawase/security/code-scanning/4)

To fix the problem, replace the fallback sanitizer's regular expression for removing `<script>` tags so that it catches all variations of script end tags accepted by browsers. This means:  
- The pattern for the closing tag should allow additional attributes and whitespace inside the closing tag, e.g. `</script foo="bar">`, not just `</script>`.
- A well-discussed solution is to match the opening `<script` tag and anything until a closing `</script` tag followed by arbitrary non-`>` characters and a `>`.
- The replacement should be in the fallbackSanitize function, specifically the line where the regular expression is defined and used to remove script tags (line 76).

We should not attempt to write a full-featured HTML sanitizer in regex; we only patch this fallback for parity with the original intent. The rest of the code does not need to change.

No additional imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
