### PR TITLE
Potential fix for code scanning alert no. 16: Incomplete multi-character sanitization

### DIFF
--- a/js/sanitize.js
+++ b/js/sanitize.js
@@ -78,7 +78,7 @@ function fallbackSanitize(content) {
     let previous;
     do {
         previous = sanitized;
-        sanitized = content.replace(/<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi, '');
+        sanitized = sanitized.replace(/<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi, '');
     } while (sanitized !== previous);
     
     // 危険なjavascript:プロトコルを除去


### PR DESCRIPTION
Potential fix for [https://github.com/blackstraysheep/Kuawase/security/code-scanning/16](https://github.com/blackstraysheep/Kuawase/security/code-scanning/16)

To correctly sanitize the string, we need to ensure the regular expression is repeatedly applied to the *mutated* string, not the original input. The best way is to perform the replacement inside the loop on the current `sanitized` value, updating it iteratively until no more replacements are detected. This ensures that any nested or fragmented `<script>` tags are completely removed.  
The only required change is in the fallbackSanitize function on lines 79–82. Specifically, replace `sanitized = content.replace(...)` with `sanitized = sanitized.replace(...)`. No additional imports or method definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
