### PR TITLE
Potential fix for code scanning alert no. 6: Incomplete multi-character sanitization

### DIFF
--- a/js/sanitize.js
+++ b/js/sanitize.js
@@ -85,7 +85,11 @@ function fallbackSanitize(content) {
     sanitized = sanitized.replace(/javascript:/gi, '');
     
     // 危険なイベントハンドラーを除去
-    sanitized = sanitized.replace(/\s*on\w+\s*=\s*["'][^"']*["']/gi, '');
+    // イベントハンドラー属性 (例: onclick, onerror等) を繰り返し除去
+    do {
+        previous = sanitized;
+        sanitized = sanitized.replace(/\s*on\w+\s*=\s*["'][^"']*["']/gi, '');
+    } while (sanitized !== previous);
     
     // 許可されたタグのみを保持
     const allowedTags = /^<\/?(?:ruby|rt|rp|span|div|p|strong|em|b|i|br|small|sup|sub)(?:\s[^>]*)?>$/i;


### PR DESCRIPTION
Potential fix for [https://github.com/blackstraysheep/Kuawase/security/code-scanning/6](https://github.com/blackstraysheep/Kuawase/security/code-scanning/6)

To correctly sanitize the content and ensure no event handler attributes ("on...") remain, the sanitization regex replacement must be applied repeatedly until the input no longer changes. This will ensure all instances, including those that result from earlier replacements, are removed—even for overlapping, adjacent, or tricky cases. Thus, in `fallbackSanitize`, replace the single call to `.replace(/\s*on\w+\s*=\s*["'][^"']*["']/gi, '')` with a loop that applies the replacement until the output stabilizes. Only this region (line 88) in `js/sanitize.js` needs to change; no new imports or external libraries are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
