### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete multi-character sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "electron-squirrel-startup": "^1.0.1",
     "electron-updater": "^6.6.2",
     "log": "^6.3.2",
-    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"
+    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz",
+    "sanitize-html": "^2.17.0"
   },
   "devDependencies": {
     "@electron-forge/cli": "^7.8.0",


### PR DESCRIPTION
Potential fix for [https://github.com/blackstraysheep/Kuawase/security/code-scanning/7](https://github.com/blackstraysheep/Kuawase/security/code-scanning/7)

The best fix is to avoid hand-rolled regular expressions for HTML sanitization, and instead, use a well-tested sanitization library, such as `sanitize-html`. However, in this specific file, the fallback is used only when `DOMPurify` is not available, and the code currently only allows a specific set of tags. To make the sanitization more robust in the fallback, rather than attempting tag whitelist/regex replacements (which are incomplete for HTML edge cases), we should use the `sanitize-html` library in Node.js environments. If that is not possible (i.e., keeping the logic portable/zero-dependency), a more robust approach is to replace all `<` and `>` characters in tags that are not in the allowed tags list, thereby guaranteeing that unsafe tags cannot survive.

**Detailed steps to fix:**
- In the fallbackSanitize function, instead of applying a potentially-incomplete tag allowlist using a regex, use the `sanitize-html` npm package to allow only the specified tags (`ruby`, `rt`, `rp`, `span`, `div`, `p`, `strong`, `em`, `b`, `i`, `br`, `small`, `sup`, `sub`).
- If you *must* avoid new dependencies, then remove all tags except allowed ones by matching them with a global regex, removing all occurrences of tags not on the allowlist in a repeated manner until no more changes occur—this reduces risk but is still fragile relative to a real parser.
- Prefer using `sanitize-html` in Node.js as an external dependency to ensure robust HTML sanitization and avoid regular expression pitfalls.

**Where to edit:**  
- Modify `fallbackSanitize` in `js/sanitize.js`, specifically replacing or updating the region using `allowedTags` and the tag-matching regex.

**Additional requirements:**  
- If using `sanitize-html`, require/import it at function scope (as with `DOMPurify` above).
- For browser compatibility, only run this in the Node.js (non-browser) environment; otherwise, fall back to existing logic or do not sanitize at all in the fallback (raise a warning).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
