### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete multi-character sanitization

### DIFF
--- a/js/sanitize.js
+++ b/js/sanitize.js
@@ -116,9 +116,13 @@ function fallbackSanitize(content) {
 
     // sanitize-html が使えない場合: 旧正規表現方式(非推奨かつ安全ではない)
     const allowedTags = /^<\/?(?:ruby|rt|rp|span|div|p|strong|em|b|i|br|small|sup|sub)(?:\s[^>]*)?>$/i;
-    sanitized = sanitized.replace(/<[^>]+>/g, (match) => {
-        return allowedTags.test(match) ? match : '';
-    });
+    // 未許可タグの除去も繰り返す
+    do {
+        previous = sanitized;
+        sanitized = sanitized.replace(/<[^>]+>/g, (match) => {
+            return allowedTags.test(match) ? match : '';
+        });
+    } while (sanitized !== previous);
 
     return sanitized;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/blackstraysheep/Kuawase/security/code-scanning/7](https://github.com/blackstraysheep/Kuawase/security/code-scanning/7)

To fix the incomplete multi-character sanitization, we need to ensure that _no disallowed HTML tags_ (especially `<script>` and others) remain after the fallback sanitizer step, even if they are nested, repeated, malformed, or introduced via tricky attacker input. The best approach within the shown code is to apply the replacement **repeatedly until no more changes occur** (`do...while` loop), similar to the pattern used earlier in the function for script and event attributes. This ensures that any new/uncovered matches generated by the previous regex pass are also removed, fully stripping out any residual HTML tags except those explicitly whitelisted. No external libraries are introduced (since in this fallback mode, sanitize-html is presumed unavailable).

**What to change:**  
- In the `fallbackSanitize` function, change the single call to `.replace(/<[^>]+>/g, ...)` on line 119, so that it is wrapped in a do-while loop, repeatedly applying the replacement until no more changes occur.
- No additional dependencies or new imports are required, and no new function is needed beyond the loop structure.
- All changes are confined to the shown section of `js/sanitize.js`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
